### PR TITLE
Adds a Jenkinsfile for FreeAgent build

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,5 @@
+#!groovy
+
+@Library('freeagent') _
+
+freeagentGem( slack: [channel: '#rails-next'] )


### PR DESCRIPTION
We're hacking to see if we can get the app to build and run on Edge Rails. Since it's a hack, we don't want to push fixes to upstream yet, so we've forked the gems.

To get it to run on our own infra, we'll need a Jenkinsfile. This is the most basic that we have, and it will push messages to a `rails-next` channel in slack.