### PR TITLE
Updates Active Record maximum version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source "https://rubygems.org"
 
-gem 'activerecord', '>= 5.2.0', '< 6.3'
+gem 'activerecord', '>= 5.2.0', '< 7.1'
 
 group :development, :test do
   gem 'spec'


### PR DESCRIPTION
Recently, Rails core announced that they would be releasing Rails 7, not Rails 6.2. Given that, we need to update the gem version constraints for activerecord.

Nothing else should change, as the gem has already been tested against master.